### PR TITLE
Allow null to be passed as instance value

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ function JsonField(db, modelName, fieldName, options) {
       if (typeof instance.dataValues[fieldName] !== 'string' && instance.dataValues[fieldName]) {
         instance.setDataValue(fieldName, JSON.stringify(instance.getDataValue(fieldName)));
         return self;
-      } else if (instance.dataValues[fieldName] === 'null' || !instance.dataValues[fieldName]) {
+      } else if (instance.dataValues[fieldName] === 'null') {
+        instance.setDataValue(fieldName, null);
+      } else if (typeof instance.dataValues[fieldName] === 'undefined') {
         instance.setDataValue(fieldName, undefined);
       }
     }
@@ -35,6 +37,10 @@ function JsonField(db, modelName, fieldName, options) {
 
   if (options.hasOwnProperty('defaultValue')) {
     model.defaultValue = JSON.stringify(options.defaultValue);
+  }
+
+  if (typeof options.allowNull === 'boolean') {
+    model.allowNull = options.allowNull;
   }
 
   return model;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-json",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Automatic serialization/parsing of JSON in your models",
   "main": "index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,17 @@ describe('Test the various uses of the JSON field', function() {
     })
     .catch(done);
   });
+  
+  it('Null should be passed as a possible value', function(done) {
+    User.create({
+      jsonField: null
+    })
+    .then(function(user) {
+      expect(user.jsonField).to.be.null;
+      done();
+    })
+    .catch(done);
+  });
 });
 
 describe('Test default values', function() {
@@ -179,6 +190,40 @@ describe('Test default values', function() {
     })
     .catch(done);
   });
+});
 
+describe('Test allowNull', function() {
 
+  beforeEach(function(done) {
+    db = new Sequelize('database', 'username', 'password', {
+      dialect: 'sqlite',
+      logging: false
+    });
+
+    User = db.define('User', {
+      username: Sequelize.STRING,
+      jsonField: new JsonField(db, 'User', 'jsonField', { allowNull: false })
+    });
+
+    db
+    .sync({ force: true })
+    .then(function() {
+      done();
+    });
+  });
+
+  it('Should reject null values with a SequelizeUniqueConstraintError', function(done) {
+    User.create({
+      username: 'Scott',
+      jsonField: null
+    })
+    .then(function() {
+      fail('null Value should have been rejected')
+      done()
+    })
+    .catch(function(error) {
+      expect(error).to.be.an.instanceof(Sequelize.UniqueConstraintError)
+      done()
+    });
+  }); 
 });


### PR DESCRIPTION
Currently it is not possible to update a JsonField with  a `null` value, even if allowNull is set to true.
This PR allows `null` to be passed as a value for instances which may be wanted when updating certain records in the database.

Also allowNull currently has no effect because the option is not passed to sequelize. This is fixed as well in this PR